### PR TITLE
gcs-rsync buildkite plugin for file copying and profit

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,18 +1,18 @@
 steps:
   - label: ":shell: Shellcheck"
     plugins:
-      shellcheck#v1.3.0:
+      shellcheck#v1.4.0:
         files:
           - hooks/**
           - scripts/**
 
   - label: ":rocket: Test"
     plugins:
-      docker-compose#v5.3.0:
+      docker-compose#v5.10.0:
         run: tests
         cli-version: 2
 
   - label: ":sparkles: Lint"
     plugins:
       plugin-linter#v3.3.0:
-        id: a-github-user/template
+        id: theopenlane/gcs-rsync

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @datumforge/blacksmiths
+* @theopenlane/blacksmiths

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Please read the [contributing](.github/CONTRIBUTING.md) guide as well as the [Developer Certificate of Origin](https://developercertificate.org/). You will be required to sign all commits to the Openlane project, so if you're unfamiliar with how to set that up, see [github's documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+
+Given external users will not have write to the branches in this repository, you'll need to follow the forking process to open a PR - [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) is a guide from github on how to do so.
+
+## Licensing
+
+This repository contains open source software that comprises the Openlane stack which is open source software under [Apache 2.0](LICENSE). Openlane's SaaS / Cloud Services are products produced from this open source software exclusively by theopenlane, Inc. This product is produced under our published commercial terms (which are subject to change). Any logos or trademarks in our repositories in [theopenlane](https://github.com/theopenlane) organization are not covered under the Apache License and are trademarks of theopenlane, Inc.
+
+Others are allowed to make their own distribution of this software or include this software in other commercial offerings, but cannot use any of the Openlane logos, trademarks, cloud services, etc.
+
+## Security
+
+We take the security of our software products and services seriously, including our commercial services and all of the open source code repositories managed through our Github Organizations, such as [theopenlane](https://github.com/theopenlane). If you believe you have found a security vulnerability in any of our repositories or in our SaaS offering(s), please report it to us through coordinated disclosure.
+
+**Please do NOT report security vulnerabilities through public github issues, discussions, or pull requests!**
+
+Instead, please send an email to `security@theopenlane.io` with as much information as possible to best help us understand and resolve the issues. See the security policy attached to this repository for more details.
+
+## Questions?
+
+You can email us at `info@theopenlane.io`, open a github issue in this repository, or reach out to [matoszz](https://github.com/matoszz) directly.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,16 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug or issue you're encountering**
+
+
+**What are the relevant steps to reproduce, including the version(s) of the relevant software?**
+
+
+**What is the expected behavior?**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request]"
+labels: enhancement
+assignees: matoszz
+
+---
+
+**Describe how the feature might make your life easier or solve a problem**
+
+**Describe the solution you'd like to see with any relevant context**
+
+**Describe any alternatives you've considered or if there are short-tern vs. long-term options**

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 *.tar
 *.zip
 
-# Logs 
+# Logs
 *.log
 
 # Editor files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+default_stages: [pre-commit]
+fail_fast: true
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: detect-private-key
+      - id: check-shebang-scripts-are-executable
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.15.0
+    hooks:
+      - id: yamlfmt
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.29.4
+    hooks:
+      - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,10 @@ repos:
       - id: detect-private-key
       - id: check-shebang-scripts-are-executable
   - repo: https://github.com/google/yamlfmt
-    rev: v0.15.0
+    rev: v0.17.0
     hooks:
       - id: yamlfmt
   - repo: https://github.com/crate-ci/typos
-    rev: v1.29.4
+    rev: v1.33.1
     hooks:
       - id: typos

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,20 @@
+[files]
+extend-exclude = ["db","internal/ent/generated/**","go.mod","go.sum","pkg/testutils/","pkg/passwd/","pkg/tokens/testdata/","pkg/tokens/expires_test.go","internal/graphapi/tools_test.go","internal/httpserve/handlers/tools_test.go","pkg/keygen/auth_test.go","pkg/utils/oas/","pkg/keygen/crypto_test.go","pkg/auth/auth_test.go"]
+ignore-hidden = true
+ignore-files = true
+ignore-dot = true
+ignore-vcs = true
+ignore-global = true
+ignore-parent = true
+
+[default]
+binary = false
+check-filename = true
+check-file = true
+unicode = true
+ignore-hex = true
+identifier-leading-digits = false
+locale = "en"
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = ["(?i)requestor","(?i)indentity","(?i)encrypter","(?i)seeked","(?i)generater"]
+extend-ignore-re = ["#\\s*spellchecker:off\\s*\\n.*\\n\\s*#\\s*spellchecker:on"]

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,4 @@
+exclude:
+  - config/
+formatter:
+  retain_line_breaks: true

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2024] [Datum Technology, Inc.]
+   Copyright [2025] [theopenlane, Inc.]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
-[![Build status](https://badge.buildkite.com/df549c652f77fa3660f4d7f975fd3bb5744e12fb4066719553.svg?branch=main)](https://buildkite.com/datum/template-buildkite-plugin)
+[![Build status](https://badge.buildkite.com/cf752698f275643f5163411a872eefef64ff44e486f386a872.svg)](https://buildkite.com/theopenlane/gcs-rsync-buildkite-plugin)
 
-# Template Buildkite Plugin
+# GCS rsync plugin
 
-Check the [buildkite organization](https://github.com/buildkite-plugins) or [website](https://buildkite.com/plugins) to see if your plugin already exists or we can contribute to it !
-
-Be sure to update this readme with your plugin information after using the template repository - for more info checkout Buildkite's documentation [here](https://buildkite.com/docs/plugins)
+This plugin uploads files from your pipeline to a Google Cloud Storage bucket using `gsutil rsync`. It runs the Cloud SDK Docker image so you don't need `gcloud` installed on the agent.
 
 ## Example
-
-Provide an example of using this plugin, like so:
 
 Add the following to your `pipeline.yml`:
 
 ```yml
 steps:
-  - command: ls
+  - command: ":"
     plugins:
-      - a-github-user/template#v1.0.0:
-          pattern: '*.md'
+      - theopenlane/gcs-rsync#v1.0.1:
+          bucket: my-upload-bucket
+          source: templates
+          project: my-gcp-project
+          service-account-key: "${GCP_SA_KEY}"
 ```
+
+### Configuration
+
+* `bucket` (**required**): The name of the GCS bucket to sync to.
+* `source`: Local directory to upload (default: `templates`).
+* `project` (**required**): GCP project ID.
+* `service-account-key` (**required**): Service account JSON key used for authentication.
+
+The plugin uses `gsutil -m rsync` to synchronize the source directory with the destination bucket.
+
+Tests can be run with `bats tests` from this directory.
 
 ## Developing
 
@@ -34,3 +44,10 @@ To run the tests:
 ```shell
 task test
 ```
+## Contributing
+
+1. Fork the repo
+2. Make the changes
+3. Run the tests
+4. Commit and push your changes
+5. Send a pull request

--- a/README.md
+++ b/README.md
@@ -44,10 +44,49 @@ To run the tests:
 ```shell
 task test
 ```
+## Practical application
+
+If you're like us, you might have super sekretz in some of your repos you want to use in your GCP account - in our case we want to bop our pods on some files we keep in a repo. After using this plugin, you'd be able to do something like:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: core
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: core
+  template:
+    metadata:
+      labels:
+        app: core
+    spec:
+      serviceAccountName: bucket-mounter
+      volumes:
+        - name: treasure-map
+          emptyDir: {}
+      containers:
+        - name: core
+          image: ghcr.io/theopenlane/core:latest
+          volumeMounts:
+            - name: treasure-map
+              mountPath: /app/treasuremaps
+        - name: gcsfuse
+          image: gcr.io/gcsfuse/gcsfuse:latest
+          command: ["/bin/sh", "-c", "gcsfuse --implicit-dirs treasure-map-bucket /treasuremaps && sleep infinity"]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: treasure-map
+              mountPath: /treasuremaps
+```
+
 ## Contributing
 
 1. Fork the repo
-2. Make the changes
-3. Run the tests
-4. Commit and push your changes
-5. Send a pull request
+1. Make the changes
+1. Run the tests
+1. Commit and push your changes
+1. Send a pull request

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,29 +1,55 @@
 version: "3"
 
 tasks:
+  default:
+    silent: true
+    cmds:
+      - task --list
+
   install:
     desc: install packages required for working with this repo
     cmds:
       - brew install shellcheck
-  
+    deps:
+      - task: brew-installed
+
   shellcheck:
     desc: shellcheck
-    cmds: 
+    cmds:
       - shellcheck hooks/** scripts/**
+    preconditions:
+      - which shellcheck
 
   lint:
     desc: runs the buildkite compose linter
     cmds:
       - docker compose run --rm lint
+    preconditions:
+      - which docker-compose
 
   test:
     desc: runs the buildkite plugin tester
     cmds:
       - docker compose run --rm tests
+    preconditions:
+      - which docker-compose
 
-  ci: 
-    desc: runs all the commands that will be run in CI 
+  ci:
+    desc: runs all the commands that will be run in CI
     cmds:
       - task: shellcheck
       - task: lint
       - task: test
+
+  precommit-full:
+    desc: Lint the project against all files
+    cmds:
+      - pre-commit install && pre-commit install-hooks
+      - pre-commit autoupdate
+      - pre-commit run --show-diff-on-failure --color=always --all-files
+
+  brew-installed:
+    silent: true
+    desc: check if Homebrew is installed
+    cmds:
+      - '[ -x "$(command -v brew)" ] || (echo "Homebrew is not installed, please install it from https://brew.sh" && exit 1)'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   # You need to update this for your plugin name / location
   lint:
     image: buildkite/plugin-linter
-    command: [ '--id', 'a-github-user/template' ]
+    command: [ '--id', 'theopenlane/gcs-rsync' ]
     volumes:
       - ".:/plugin:ro"
   tests:

--- a/hooks/command
+++ b/hooks/command
@@ -5,7 +5,7 @@ set -euo pipefail
 plugin_read_config() {
   local name="$1"
   local default="${2:-}"
-  local var="BUILDKITE_PLUGIN_GCS_RSYNC_${name^^}"
+  local var="BUILDKITE_PLUGIN_GCS_RSYNC_$(echo "$name" | tr '[:lower:]' '[:upper:]')"
   var="${var//-/_}"
   echo "${!var:-$default}"
 }

--- a/hooks/command
+++ b/hooks/command
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper to read configuration variables
+plugin_read_config() {
+  local name="$1"
+  local default="${2:-}"
+  local var="BUILDKITE_PLUGIN_GCS_RSYNC_${name^^}"
+  var="${var//-/_}"
+  echo "${!var:-$default}"
+}
+
+BUCKET="$(plugin_read_config bucket)"
+SOURCE="$(plugin_read_config source templates)"
+PROJECT="$(plugin_read_config project)"
+SA_KEY="$(plugin_read_config service-account-key)"
+
+if [[ -z "$BUCKET" || -z "$PROJECT" || -z "$SA_KEY" ]]; then
+  echo "Missing required configuration" >&2
+  exit 1
+fi
+
+echo "$SA_KEY" > sa-key.json
+trap 'rm -f sa-key.json' EXIT
+
+docker run --rm \
+  -v "$PWD":/workspace \
+  -w /workspace \
+  gcr.io/google.com/cloudsdktool/cloud-sdk:slim \
+  bash -c "gcloud auth activate-service-account --key-file sa-key.json && gcloud config set project $PROJECT && gsutil -m rsync -r $SOURCE gs://$BUCKET/"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -o errexit # script exits when a command fails == set -e
-set -o nounset # script exits when tries to use undeclared variables == set -u
-set -o xtrace # trace what's executed == set -x (useful for debugging)
-set -o pipefail # causes pipelines to retain / set the last non-zero status

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,14 +1,24 @@
----
-name: template-buildkite-plugin
-description: what your plugin does
-author: Datum
+name: gcs-rsync
+description: Sync a local directory to a Google Cloud Storage bucket using gsutil
+author: https://github.com/theopenlane
 requirements:
-  - if you have requirements
+  - bash
 configuration:
   properties:
-    propertyname:
+    bucket:
       type: string
-  required: []
-    # - if any properties are required
-  dependencies:
-    dependencyname: [dep]
+      description: The name of the GCS bucket to sync to
+    source:
+      type: string
+      description: The local directory to sync
+    project:
+      type: string
+      description: The GCP project ID
+    service-account-key:
+      type: string
+      description: The path to the service account key file
+  required:
+    - bucket
+    - project
+    - service-account-key
+  additionalProperties: false

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,21 @@
 {
-    "extends": [
-      "config:base"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:enableMajor",
+    ":gitSignOff"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+        {
+            "groupName": "all patch dependencies",
+            "groupSlug": "all-patch",
+            "matchPackageNames": [
+                "*"
+            ],
+            "matchUpdateTypes": [
+                "patch"
+            ]
+        }
     ]
-  }
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+load "test_helper.bash"
+
+@test "fails without bucket" {
+  run "$HOOK"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Missing required configuration"* ]]
+}
+
+@test "invokes gsutil rsync in docker" {
+  export BUILDKITE_PLUGIN_GCS_RSYNC_BUCKET="my-bucket"
+  export BUILDKITE_PLUGIN_GCS_RSYNC_SOURCE="templates"
+  export BUILDKITE_PLUGIN_GCS_RSYNC_SERVICE_ACCOUNT_KEY='{}'
+
+  run "$HOOK"
+  [ "$status" -eq 0 ]
+  grep -q "gsutil -m rsync" "$DOCKER_CMD"
+  grep -q "templates" "$DOCKER_CMD"
+  grep -q "my-bucket" "$DOCKER_CMD"
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,7 +3,9 @@
 load "test_helper.bash"
 
 @test "fails without bucket" {
-  run "$HOOK"
+  run "$HOOK" 2>&1
+  echo "status: $status"
+  echo "output: $output"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Missing required configuration"* ]]
 }
@@ -12,8 +14,11 @@ load "test_helper.bash"
   export BUILDKITE_PLUGIN_GCS_RSYNC_BUCKET="my-bucket"
   export BUILDKITE_PLUGIN_GCS_RSYNC_SOURCE="templates"
   export BUILDKITE_PLUGIN_GCS_RSYNC_SERVICE_ACCOUNT_KEY='{}'
+  export BUILDKITE_PLUGIN_GCS_RSYNC_PROJECT="my-project"
 
-  run "$HOOK"
+  run "$HOOK" 2>&1
+  echo "status: $status"
+  echo "output: $output"
   [ "$status" -eq 0 ]
   grep -q "gsutil -m rsync" "$DOCKER_CMD"
   grep -q "templates" "$DOCKER_CMD"

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -1,3 +1,0 @@
-#!/usr/bin/env bats
-
-PROJECT_DIR=$(cd "${BATS_TEST_DIRNAME}/.." && pwd)

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,11 @@
+setup() {
+  export HOOK="$(dirname "$BATS_TEST_DIRNAME")/hooks/command"
+  export DOCKER_CMD="$BATS_TMPDIR/docker_cmd"
+  mkdir -p "$BATS_TMPDIR"
+  cat <<'EOH' > "$BATS_TMPDIR/docker"
+#!/usr/bin/env bash
+printf "%s\n" "$@" > "$DOCKER_CMD"
+EOH
+  chmod +x "$BATS_TMPDIR/docker"
+  PATH="$BATS_TMPDIR:$PATH"
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,11 +1,11 @@
 setup() {
   export HOOK="$(dirname "$BATS_TEST_DIRNAME")/hooks/command"
   export DOCKER_CMD="$BATS_TMPDIR/docker_cmd"
-  mkdir -p "$BATS_TMPDIR"
-  cat <<'EOH' > "$BATS_TMPDIR/docker"
+  mkdir -p "$BATS_TMPDIR/bin"
+  cat <<'EOH' > "$BATS_TMPDIR/bin/docker"
 #!/usr/bin/env bash
 printf "%s\n" "$@" > "$DOCKER_CMD"
 EOH
-  chmod +x "$BATS_TMPDIR/docker"
-  PATH="$BATS_TMPDIR:$PATH"
+  chmod +x "$BATS_TMPDIR/bin/docker"
+  PATH="$BATS_TMPDIR/bin:$PATH"
 }


### PR DESCRIPTION
Establishes a basic buildkite plugin for moving repo contents -> gcs. Building as a BK plugin because my crystal ball says we'll have more use cases for needing `repo stuff` shoved all up in `gcp stuff`.

- uses `gcloud` and `gsutil` in combination with provided credentials and configuration to transmit files
- no pre-checks or other validation are performed if bucket does not exist or credentials are invalid (can be later enhanced)
- chose to use pre-built docker + CLI utilities because creating a `main.go` and using the cloud-sdk proved more convoluted than initially expected
- added bats tests but for the record bats tests are terrible

```bash
➜  gcs-rsync-buildkite-plugin git:(init) ✗ bats tests
command.bats
 ✓ fails without bucket
 ✓ invokes gsutil rsync in docker

2 tests, 0 failures

➜  gcs-rsync-buildkite-plugin git:(init) ✗ task lint
task: [lint] docker compose run --rm lint
TAP version 14
ok 1 - plugin.yml configuration is valid
ok 2 - All the readme config examples for plugin id 'theopenlane/gcs-rsync' are valid (1 found)
ok 3 - There are no valid tags to compare to # SKIP
1..3
# { total: 3, pass: 2, skip: 1 }
# time=134.436ms
```