### PR TITLE
Add narrow scoped audience and buildkite-agent OIDC token

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ":"
     plugins:
-      - theopenlane/gcs-rsync#v1.0.1:
+      - theopenlane/gcs-rsync#v1.0.2:
           bucket: my-upload-bucket
           source: templates
           project: my-gcp-project
           project-number: "123456789"
           pool-id: "my-pool"
-          provider-id: "my-provider"
           service-account: "my-sa@my-gcp-project.iam.gserviceaccount.com"
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ steps:
 * `project` (**required**): GCP project ID.
 * `project-number` (**required**): Numeric GCP project number.
 * `pool-id` (**required**): Workload identity pool ID.
-* `provider-id` (**required**): Workload identity provider ID.
 * `service-account` (**required**): Service account email used for authentication.
 
 The pre-command hook uses the supplied OIDC token file to generate a temporary

--- a/hooks/command
+++ b/hooks/command
@@ -16,11 +16,10 @@ SOURCE="$(plugin_read_config source templates)"
 PROJECT="$(plugin_read_config project)"
 PROJECT_NUMBER="$(plugin_read_config project-number)"
 POOL_ID="$(plugin_read_config pool-id)"
-PROVIDER_ID="$(plugin_read_config provider-id)"
 SERVICE_ACCOUNT="$(plugin_read_config service-account)"
 CRED_FILE="${GCS_RSYNC_WIF_CRED_FILE:-}"
 
-if [[ -z "$BUCKET" || -z "$PROJECT" || -z "$PROJECT_NUMBER" || -z "$POOL_ID" || -z "$PROVIDER_ID" || -z "$SERVICE_ACCOUNT" ]]; then
+if [[ -z "$BUCKET" || -z "$PROJECT" || -z "$PROJECT_NUMBER" || -z "$POOL_ID" || -z "$SERVICE_ACCOUNT" ]]; then
   echo "Missing required configuration" >&2
   exit 1
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -3,8 +3,6 @@ set -euo pipefail
 
 echo "~~~ :buildkite: Requesting OIDC token from Buildkite"
 
-REPO=$(echo "${BUILDKITE_REPO}" | awk -F'[:.]' '{ printf $3 }')
-
 # Helper to read configuration variables
 plugin_read_config() {
   local name="$1"
@@ -18,13 +16,21 @@ plugin_read_config() {
 PROJECT_NUMBER="$(plugin_read_config project-number)"
 POOL_ID="$(plugin_read_config pool-id)"
 SERVICE_ACCOUNT="$(plugin_read_config service-account)"
+REPO=$(echo "${BUILDKITE_REPO}" | awk -F'[:.]' '{ printf $3 }')
+AUDIENCE="//iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${REPO}"
 
-if [[ -z "$PROJECT_NUMBER" || -z "$POOL_ID" || -z "$PROVIDER_ID" || -z "$SERVICE_ACCOUNT" ]]; then
+if [[ -z "$PROJECT_NUMBER" || -z "$POOL_ID" || -z "$SERVICE_ACCOUNT" ]]; then
   echo "Missing required configuration" >&2
   exit 1
 fi
 
-echo "$BUILDKITE_OIDC_TOKEN" > /tmp/oidc-token
+if ! command -v buildkite-agent >/dev/null; then
+  echo "buildkite-agent command not found" >&2
+  exit 1
+fi
+
+OIDC_TOKEN="$(buildkite-agent oidc request-token --audience "${AUDIENCE}")"
+echo "$OIDC_TOKEN" > /tmp/oidc-token
 
 tmpfile="$(mktemp -p "$PWD" gcloud-wif-creds.XXXXXX)"
 CRED_FILE="${tmpfile}.json"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "~~~ :buildkite: Requesting OIDC token from Buildkite"
+
+REPO=$(echo "${BUILDKITE_REPO}" | awk -F'[:.]' '{ printf $3 }')
+
 # Helper to read configuration variables
 plugin_read_config() {
   local name="$1"
@@ -13,7 +17,6 @@ plugin_read_config() {
 
 PROJECT_NUMBER="$(plugin_read_config project-number)"
 POOL_ID="$(plugin_read_config pool-id)"
-PROVIDER_ID="$(plugin_read_config provider-id)"
 SERVICE_ACCOUNT="$(plugin_read_config service-account)"
 
 if [[ -z "$PROJECT_NUMBER" || -z "$POOL_ID" || -z "$PROVIDER_ID" || -z "$SERVICE_ACCOUNT" ]]; then
@@ -32,7 +35,7 @@ docker run --rm \
   -w /workspace \
   gcr.io/google.com/cloudsdktool/cloud-sdk:slim \
   gcloud iam workload-identity-pools create-cred-config \
-    projects/"${PROJECT_NUMBER}"/locations/global/workloadIdentityPools/"${POOL_ID}"/providers/"${PROVIDER_ID}" \
+    projects/"${PROJECT_NUMBER}"/locations/global/workloadIdentityPools/"${POOL_ID}"/providers/"${REPO}" \
     --service-account="${SERVICE_ACCOUNT}" \
     --output-file=/workspace/'$(basename "$CRED_FILE")' \
     --credential-source-file=/tmp/oidc-token

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,9 +20,6 @@ configuration:
     pool-id:
       type: string
       description: Workload identity pool ID
-    provider-id:
-      type: string
-      description: Workload identity provider ID
     service-account:
       type: string
       description: Service account email used for authentication
@@ -31,6 +28,5 @@ configuration:
     - project
     - project-number
     - pool-id
-    - provider-id
     - service-account
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -16,9 +16,7 @@ load "test_helper.bash"
   export BUILDKITE_PLUGIN_GCS_RSYNC_PROJECT="my-project"
   export BUILDKITE_PLUGIN_GCS_RSYNC_PROJECT_NUMBER="123456789"
   export BUILDKITE_PLUGIN_GCS_RSYNC_POOL_ID="my-pool"
-  export BUILDKITE_PLUGIN_GCS_RSYNC_PROVIDER_ID="my-provider"
   export BUILDKITE_PLUGIN_GCS_RSYNC_SERVICE_ACCOUNT="sa@example.com"
-  export BUILDKITE_OIDC_TOKEN="meow"
 
   source "$PRE_HOOK"
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -8,5 +8,17 @@ setup() {
 printf "%s\n" "$@" > "$DOCKER_CMD"
 EOH
   chmod +x "$BATS_TMPDIR/bin/docker"
+
+  cat <<'EOH' > "$BATS_TMPDIR/bin/buildkite-agent"
+#!/usr/bin/env bash
+if [[ "$1" == "oidc" && "$2" == "request-token" ]]; then
+  echo "meow"
+else
+  echo "unknown command" >&2
+  exit 1
+fi
+EOH
+  chmod +x "$BATS_TMPDIR/bin/buildkite-agent"
   PATH="$BATS_TMPDIR/bin:$PATH"
+  export BUILDKITE_REPO="git@github.com:theopenlane/test-repo.git"
 }


### PR DESCRIPTION
- buildkite does not stash an OIDC token directly in an env var, you need to request it from the agent directly
- requesting OIDC token from the agent requires you pass it a relatively complicated string including all your GCP project information but most specifically the "provider ID" which I've configured to be in the format of `org/reponame`
- comes up with the most creative BATS test I think I've ever written